### PR TITLE
run regression across all time-samples at once

### DIFF
--- a/functions/lmeEEG_regress.m
+++ b/functions/lmeEEG_regress.m
@@ -1,4 +1,6 @@
 function [tval, b, se] = lmeEEG_regress(y,X)
+% y can be a column [n 1] or matrix [n, nY] now, to allow it to work across 
+% all time-points at once. edited by John P. Grogan, 2024
 % adapted from:
 % REGRESS Multiple linear regression using least squares.
 %   References:
@@ -9,8 +11,7 @@ function [tval, b, se] = lmeEEG_regress(y,X)
 %          ed., Wiley.
 %   Copyright 1993-2014 The MathWorks, Inc.
 
-
-
+nY = size(y,2); % number of columns of Y passed in - e.g. time-samples
 
 [n,ncolX] = size(X);
 % Use the rank-revealing QR to remove dependent columns of X.
@@ -31,24 +32,25 @@ end
 
 % Compute the LS coefficients, filling in zeros in elements corresponding
 % to rows of X that were thrown out.
-b = zeros(ncolX,1);
-b(perm) = R \ (Q'*y);
+% Column of coefficients per column in Y
+b = zeros(ncolX,nY);
+b(perm,:) = R \ (Q'*y);
 
 
 % compute SE e tval
 RI = R\eye(p);
-nu = max(0,n-p);                % Residual degrees of freedom
+nu = max(0,n-p);                % Residual degrees of freedom, same for all columns
 yhat = X*b;                     % Predicted responses at each data point.
 r = y-yhat;                     % Residuals.
-normr = norm(r);
+normr = vecnorm(r);             % get norm per column
 if nu ~= 0
     rmse = normr/sqrt(nu);      % Root mean square error.
 else
     rmse = NaN;
 end
 
-se = zeros(ncolX,1);
-se(perm,:) = rmse*sqrt(sum(abs(RI).^2,2));
+se = zeros(ncolX,nY); % per column
+se(perm,:) = rmse .* sqrt(sum(abs(RI).^2,2)); % per column
 tval = b./se;
 
 


### PR DESCRIPTION
this allows lmeEEG_regress to take in a matrix with one column per time-point, and run the ols regressions across each time-point in one step, speeding up the channel/timepoints loop and allowing you to parfor along channels too